### PR TITLE
build and gtest when push or PR

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,16 @@
+name: build and test
+on: [push, pull_request]
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: dependency (ubuntu)
+        run: |
+          sudo apt -qy install \
+              build-essential make libgtest-dev pybind11-dev \
+              python3 python3-pip python3-pybind11 python3-pytest
+      - name: build
+        run: make
+      - name: gtest
+        run: make gtest

--- a/Makefile
+++ b/Makefile
@@ -17,11 +17,10 @@ PY_FLAGS := \
 all: py
 
 py: $(SRC) $(INC)
-	@pip install pybind11
-	$(CXX) $(CXX_FLAGS) $(PY_FLAGS) $(SRC) -o $(NAME).so
+	$(CXX) $(SRC) -o $(NAME).so $(CXX_FLAGS) $(PY_FLAGS)
 
 gtest: $(SRC) $(INC) $(TEST)
-	$(CXX) $(CXX_FLAGS) $(GTEST_FLAGS) $(SRC) $(TEST) -o $(NAME)
+	$(CXX) $(SRC) $(TEST) -o $(NAME) $(CXX_FLAGS) $(GTEST_FLAGS)
 	./$(NAME)
 
 .PHONY: clean


### PR DESCRIPTION
Setting up CI for #7 
The runner is `ubuntu-latest`, and installs gtest, pybind11, etc.
The job first build the python dynamic library with `make`, then test the c++ source code with `make gtest`.