### PR TITLE
AreaEnum, tested; allow PointFinding on top/right boarder

### DIFF
--- a/src/stitch.cpp
+++ b/src/stitch.cpp
@@ -5,16 +5,21 @@
 Stitch::Stitch(const Pt& coord, const Pt& size) : coord_(coord), size_(size) {
   assert(coord_.InQuadrantI() && "coord must lies in Quadrant I");
   assert(size_.IsSize() && "illegal size");
+  assert(size_.x > 0 && size_.y > 0 && "plane without area is no supported");
 }
 
 Id Stitch::PointFinding(const Pt& p, Id start) const {
   Id id = Exist(start) ? start : LastInserted();
-  while (id != kNullId && !Ref(id).Contain(p)) {
+  Id prev_id = kNullId;
+  while (id != kNullId && !Ref(id).Contain(p) && id != prev_id) {
+    prev_id = id;
     // move up/down using rt/lb, until the tile's vertical range contains y
     while (id != kNullId) {
       const auto& t = Ref(id);
       auto cmp_y = t.CmpY(p);
       if (cmp_y == Tile::EQ)
+        break;
+      else if (cmp_y == Tile::GT && t.rt == kNullId)
         break;
       else
         id = (cmp_y == Tile::LT) ? t.lb : t.rt;
@@ -24,6 +29,8 @@ Id Stitch::PointFinding(const Pt& p, Id start) const {
       const auto& t = Ref(id);
       auto cmp_x = t.CmpX(p);
       if (cmp_x == Tile::EQ)
+        break;
+      else if (cmp_x == Tile::GT && t.tr == kNullId)
         break;
       else
         id = (cmp_x == Tile::LT) ? t.bl : t.tr;
@@ -120,6 +127,61 @@ Id Stitch::AreaSearch(const Tile& area, Id start) const {
     }
   }
   return (Exist(id) && !Ref(id).is_space) ? id : kNullId;
+}
+
+std::vector<Id> Stitch::AreaEnum(const Tile& area, Id start) const {
+  assert(Tile(coord_, size_).Contain(area) &&
+         "search area must inside the whole plane");
+  std::vector<Id> enums;
+  // Point-finding the tile containing upper-left corner of the area
+  Id id = PointFinding(area.UpperLeftCorner(), start);
+  if (!area.Overlap(Ref(id))) {  // look for bottom neighbors
+    for (id = Ref(id).lb; Exist(id); id = Ref(id).tr)
+      if (area.Overlap(Ref(id))) break;
+  }
+  // Step down through all the tiles along the left edge, as in AreaSearch
+  while (Exist(id) &&
+         Ref(id).OverlapVerticalLine(area.LowerLeftCorner(), area.size.y)) {
+    AreaEnumHelper(area, enums, id);  // calling helper (R procedure)
+    // move down to the next tile overlapping the area
+    for (id = Ref(id).lb; Exist(id); id = Ref(id).tr) {
+      if (Ref(id).OverlapVerticalLine(area.LowerLeftCorner(), area.size.y))
+        break;
+    }
+  }
+  return enums;
+}
+
+void Stitch::AreaEnumHelper(const Tile& area, std::vector<Id>& enums,
+                            Id id) const {
+  // 1. Enumerate the tile
+  enums.push_back(id);
+  // 2. If the right edge of the tile is outside of the search area, return
+  if (!area.OverlapVerticalLine(Ref(id).LowerRightCorner(), Ref(id).size.y))
+    return;
+  // 3. Otherwise, use the neighbor-finding algorithm to locate all the tiles
+  // that touch the right side of the current tile and also intersect the
+  // searching area.
+  for (const auto& i : RightNeighborFinding(id)) {
+    if (area.Overlap(Ref(i))) {
+      // 4. For each of these neighbors, if the bottom left corner of the
+      // neighbor touches the current tile then call R to enumerate the
+      // neighbor recursively.
+      const auto& llc = Ref(i).LowerLeftCorner();
+      if (Ref(id).LowerRightCorner().x == llc.x &&
+          Ref(id).CmpY(llc.y) == Tile::EQ) {
+        AreaEnumHelper(area, enums, i);
+      }
+      // 5. Or, if the bottom edge of the search area cuts both the current
+      // tile and the neighbor, then call R to enumerate the neighbor
+      // recursively.
+      else if (  //
+          Ref(id).OverlapHorizontalLine(area.LowerLeftCorner(), area.size.x) &&
+          Ref(i).OverlapHorizontalLine(area.LowerLeftCorner(), area.size.x)) {
+        AreaEnumHelper(area, enums, i);
+      }
+    }
+  }
 }
 
 Id Stitch::LastInserted() const {

--- a/src/stitch.hpp
+++ b/src/stitch.hpp
@@ -32,8 +32,16 @@ class Stitch {
   std::vector<Id> BottomNeighborFinding(Id id) const;
   // find the left-most-top solid tile in the given area
   Id AreaSearch(const Tile& area, Id start = kNullId) const;
+  // enumerate all tiles in the given area,
+  // each tile is visited after all its upper & left tiles are visited
+  std::vector<Id> AreaEnum(const Tile& area, Id start = kNullId) const;
+
   Tile& InsertTile(Tile Tile);
   Tile& DeleteTile(Tile Tile);
+
+ protected:
+  // the recursive R procedure called by AreaEnum
+  void AreaEnumHelper(const Tile& area, std::vector<Id>& enums, Id id) const;
 
 #ifdef GTEST
  public:

--- a/src/tile.hpp
+++ b/src/tile.hpp
@@ -21,8 +21,8 @@ struct Pt {
   bool InQuadrantI() const { return (x >= 0) && (y >= 0); }
   // represents legal width & height relative to `coord` (default:(0, 0))
   bool IsSize(const Pt& coord = {0, 0}) const {
-    return (0 < x) && (x <= (kLenMax - coord.x)) &&  //
-           (0 < y) && (y <= (kLenMax - coord.y));
+    return (0 <= x) && (x <= (kLenMax - coord.x)) &&  //
+           (0 <= y) && (y <= (kLenMax - coord.y));
   }
 };
 
@@ -83,11 +83,13 @@ struct Tile {
   }
   /* `t` geometrically overlaps with this tile */
   bool Overlap(const Tile& t) const { return OverlapX(t) && OverlapY(t); }
-  /* the vertical line at `coord` with length `l` */
+  /* the vertical line at `coord` with length `l` overlaps? */
   bool OverlapVerticalLine(const Pt& coord, Len l) const {
-    Tile line;
-    line.coord = coord, line.size = Pt(0, l);
-    return Overlap(line);
+    return Overlap({coord, {0, l}});
+  }
+  /* the horizontal line at `coord` with length `l` overlaps? */
+  bool OverlapHorizontalLine(const Pt& coord, Len l) const {
+    return Overlap({coord, {l, 0}});
   }
 
   bool IsRightNeighborTo(const Tile& t) const {


### PR DESCRIPTION
#12 
Implemented `AreaEnum` to enumerate all tiles within a given area.
The order guarantees that each tile is enumerated only when all its above and left tiles are already enumerated.

`PointFinding` now support search on top/right boarder of the stitch plane.
Tests are also modified for the new behavior.
Previously, it was left-closed-right-opened which points on top/right boarder cannot be search (return `knullId`).