### PR TITLE
Tile split merge

### DIFF
--- a/src/stitch.cpp
+++ b/src/stitch.cpp
@@ -235,23 +235,19 @@ Id Stitch::VerticalSplit(Id left, Len x) {
   // 2. for lower, if rt = orig, change to new if it touches new
   for (auto id : bottom_neighbors) {
     if (Ref(id).rt == left) {
-      if (Ref(right).IsTopNeighborTo(Ref(id))) {
-        Ref(id).rt = right;
-        // the first satisfying below must be the right-most
-        if (Ref(right).lb == kNullId) Ref(right).lb = id;
-      }
+      if (Ref(right).IsTopNeighborTo(Ref(id))) Ref(id).rt = right;
     }
+    if (Ref(right).lb == kNullId && Ref(right).IsTopNeighborTo(Ref(id)))
+      Ref(right).lb = id;  // must be the left-most
   }
   // 3. for top, if lb = orig, change to new if it does not touch orig
   for (auto id : top_neighbors) {
     if (Ref(id).lb == left) {
       Ref(id).lb = right;  // flip
-      if (Ref(left).IsBottomNeighborTo(Ref(id))) {
-        Ref(id).lb = left;
-        // the first satisfying below must be the right-most
-        if (Ref(left).rt == kNullId) Ref(left).rt = id;
-      }
+      if (Ref(left).IsBottomNeighborTo(Ref(id))) Ref(id).lb = left;
     }
+    if (Ref(left).rt == kNullId && Ref(left).IsBottomNeighborTo(Ref(id)))
+      Ref(left).rt = id;  // must be the right-most
   }
   return right;
 }
@@ -284,23 +280,19 @@ Id Stitch::HorizontalSplit(Id lower, Len y) {
   // 2. for left, if tr = orig, change to new if it touches new
   for (auto id : left_neighbors) {
     if (Ref(id).tr == lower) {
-      if (Ref(upper).IsRightNeighborTo(Ref(id))) {
-        Ref(id).tr = upper;
-        // the first satisfying below must be the lowest
-        if (Ref(upper).bl == kNullId) Ref(upper).bl = id;
-      }
+      if (Ref(upper).IsRightNeighborTo(Ref(id))) Ref(id).tr = upper;
     }
+    if (Ref(upper).bl == kNullId && Ref(upper).IsRightNeighborTo(Ref(id)))
+      Ref(upper).bl = id;  // must be the lowest
   }
   // 3. for right, if bl = orig, change to to new if it does not touch orig
   for (auto id : right_neighbors) {
     if (Ref(id).bl == lower) {
       Ref(id).bl = upper;  // flip
-      if (Ref(lower).IsLeftNeighborTo(Ref(id))) {
-        Ref(id).bl = lower;
-        // the first satisfying below must be the highest
-        if (Ref(lower).tr == kNullId) Ref(lower).tr = id;
-      }
+      if (Ref(lower).IsLeftNeighborTo(Ref(id))) Ref(id).bl = lower;
     }
+    if (Ref(lower).tr == kNullId && Ref(lower).IsLeftNeighborTo(Ref(id)))
+      Ref(lower).tr = id;  // must be the highest
   }
   return upper;
 }

--- a/src/stitch.cpp
+++ b/src/stitch.cpp
@@ -234,18 +234,15 @@ Id Stitch::VerticalSplit(Id left, Len x) {
     if (Ref(id).bl == left) Ref(id).bl = right;
   // 2. for lower, if rt = orig, change to new if it touches new
   for (auto id : bottom_neighbors) {
-    if (Ref(id).rt == left) {
-      if (Ref(right).IsTopNeighborTo(Ref(id))) Ref(id).rt = right;
-    }
+    if (Ref(id).rt == left && Ref(right).IsTopNeighborTo(Ref(id)))
+      Ref(id).rt = right;
     if (Ref(right).lb == kNullId && Ref(right).IsTopNeighborTo(Ref(id)))
       Ref(right).lb = id;  // must be the left-most
   }
   // 3. for top, if lb = orig, change to new if it does not touch orig
   for (auto id : top_neighbors) {
-    if (Ref(id).lb == left) {
-      Ref(id).lb = right;  // flip
-      if (Ref(left).IsBottomNeighborTo(Ref(id))) Ref(id).lb = left;
-    }
+    if (Ref(id).lb == left && !Ref(left).IsBottomNeighborTo(Ref(id)))
+      Ref(id).lb = right;
     if (Ref(left).rt == kNullId && Ref(left).IsBottomNeighborTo(Ref(id)))
       Ref(left).rt = id;  // must be the right-most
   }
@@ -279,18 +276,15 @@ Id Stitch::HorizontalSplit(Id lower, Len y) {
     if (Ref(id).lb == lower) Ref(id).lb = upper;
   // 2. for left, if tr = orig, change to new if it touches new
   for (auto id : left_neighbors) {
-    if (Ref(id).tr == lower) {
-      if (Ref(upper).IsRightNeighborTo(Ref(id))) Ref(id).tr = upper;
-    }
+    if (Ref(id).tr == lower && Ref(upper).IsRightNeighborTo(Ref(id)))
+      Ref(id).tr = upper;
     if (Ref(upper).bl == kNullId && Ref(upper).IsRightNeighborTo(Ref(id)))
       Ref(upper).bl = id;  // must be the lowest
   }
   // 3. for right, if bl = orig, change to to new if it does not touch orig
   for (auto id : right_neighbors) {
-    if (Ref(id).bl == lower) {
-      Ref(id).bl = upper;  // flip
-      if (Ref(lower).IsLeftNeighborTo(Ref(id))) Ref(id).bl = lower;
-    }
+    if (Ref(id).bl == lower && !Ref(lower).IsLeftNeighborTo(Ref(id)))
+      Ref(id).bl = upper;
     if (Ref(lower).tr == kNullId && Ref(lower).IsLeftNeighborTo(Ref(id)))
       Ref(lower).tr = id;  // must be the highest
   }

--- a/src/stitch.hpp
+++ b/src/stitch.hpp
@@ -36,12 +36,8 @@ class Stitch {
   // each tile is visited after all its upper & left tiles are visited
   std::vector<Id> AreaEnum(const Tile& area, Id start = kNullId) const;
 
-  Tile& InsertTile(Tile Tile);
-  Tile& DeleteTile(Tile Tile);
-
- protected:
-  // the recursive R procedure called by AreaEnum
-  void AreaEnumHelper(const Tile& area, std::vector<Id>& enums, Id id) const;
+  Id InsertTile(Tile tile);
+  Id DeleteTile(Tile tile);
 
 #ifdef GTEST
  public:
@@ -64,4 +60,16 @@ class Stitch {
            tiles_[id].has_value();
   }
   Id LastInserted() const;
+  // the recursive R procedure called by AreaEnum
+  void AreaEnumHelper(const Tile& area, std::vector<Id>& enums, Id id) const;
+  // allocate a new tile, return its id
+  Id AllocTile();
+  // free tile `id`, return 0 if success else return 1
+  int FreeTile(Id id);
+  // vertically split tile `id` along line x=`x`
+  Id VerticalSplit(Id id, Len x);
+  // horizontally split tile `id` along line y=`y`
+  Id HorizontalSplit(Id id, Len y);
+  // Merge tiles `id1` & `id2`
+  Id Merge(Id id1, Id id2);
 };

--- a/src/stitch.hpp
+++ b/src/stitch.hpp
@@ -66,10 +66,12 @@ class Stitch {
   Id AllocTile();
   // free tile `id`, return 0 if success else return 1
   int FreeTile(Id id);
-  // vertically split tile `id` along line x=`x`
+  // vertically split tile `id` along line x=`x`, return the created new tile
   Id VerticalSplit(Id id, Len x);
-  // horizontally split tile `id` along line y=`y`
+  // horizontally split tile `id` along line y=`y`, return the created new tile
   Id HorizontalSplit(Id id, Len y);
-  // Merge tiles `id1` & `id2`
-  Id Merge(Id id1, Id id2);
+  // vertically merge tiles `left` & `right`, return the merged tile
+  Id VerticalMerge(Id left, Id right);
+  // horizontally merge tiles `lower` & `upper`, return the merged tile
+  Id HorizontalMerge(Id lower, Id upper);
 };

--- a/test/stitch.cpp
+++ b/test/stitch.cpp
@@ -263,6 +263,16 @@ TEST(test_helper, Neighbors) {
   }
 }
 
+void CheckNeighbors(const Stitch& s) {
+  for (size_t id = 0; id < s.tiles_.size(); id++) {
+    if (!s.tiles_[id].has_value()) continue;
+    EXPECT_EQ(Neighbors(s, id, RIGHT), s.RightNeighborFinding(id)) << id;
+    EXPECT_EQ(Neighbors(s, id, LEFT), s.LeftNeighborFinding(id)) << id;
+    EXPECT_EQ(Neighbors(s, id, TOP), s.TopNeighborFinding(id)) << id;
+    EXPECT_EQ(Neighbors(s, id, BOTTOM), s.BottomNeighborFinding(id)) << id;
+  }
+}
+
 TEST(Stitch, VerticalSplit1) {
   Example example = Example::Example1();
   auto& s = example.stitch;
@@ -274,30 +284,7 @@ TEST(Stitch, VerticalSplit1) {
   for (auto id : ids) {
     auto n_id = s.VerticalSplit(id, s.Ref(id).coord.x + s.Ref(id).size.x / 2);
     EXPECT_NE(n_id, id) << "should return id of new tile";
-    for (auto side : {RIGHT, LEFT, TOP, BOTTOM}) {
-      switch (side) {
-        case RIGHT:
-          EXPECT_EQ(Neighbors(s, id, side), s.RightNeighborFinding(id)) << id;
-          EXPECT_EQ(Neighbors(s, n_id, side), s.RightNeighborFinding(n_id))
-              << n_id;
-          break;
-        case LEFT:
-          EXPECT_EQ(Neighbors(s, id, side), s.LeftNeighborFinding(id)) << id;
-          EXPECT_EQ(Neighbors(s, n_id, side), s.LeftNeighborFinding(n_id))
-              << n_id;
-          break;
-        case TOP:
-          EXPECT_EQ(Neighbors(s, id, side), s.TopNeighborFinding(id)) << id;
-          EXPECT_EQ(Neighbors(s, n_id, side), s.TopNeighborFinding(n_id))
-              << n_id;
-          break;
-        default:
-          EXPECT_EQ(Neighbors(s, id, side), s.BottomNeighborFinding(id)) << id;
-          EXPECT_EQ(Neighbors(s, n_id, side), s.BottomNeighborFinding(n_id))
-              << n_id;
-          break;
-      }
-    }
+    CheckNeighbors(s);
   }
 }
 
@@ -312,29 +299,6 @@ TEST(Stitch, HorizontalSplit1) {
   for (auto id : ids) {
     auto n_id = s.HorizontalSplit(id, s.Ref(id).coord.y + s.Ref(id).size.y / 2);
     EXPECT_NE(n_id, id) << "should return id of new tile";
-    for (auto side : {RIGHT, LEFT, TOP, BOTTOM}) {
-      switch (side) {
-        case RIGHT:
-          EXPECT_EQ(Neighbors(s, id, side), s.RightNeighborFinding(id)) << id;
-          EXPECT_EQ(Neighbors(s, n_id, side), s.RightNeighborFinding(n_id))
-              << n_id;
-          break;
-        case LEFT:
-          EXPECT_EQ(Neighbors(s, id, side), s.LeftNeighborFinding(id)) << id;
-          EXPECT_EQ(Neighbors(s, n_id, side), s.LeftNeighborFinding(n_id))
-              << n_id;
-          break;
-        case TOP:
-          EXPECT_EQ(Neighbors(s, id, side), s.TopNeighborFinding(id)) << id;
-          EXPECT_EQ(Neighbors(s, n_id, side), s.TopNeighborFinding(n_id))
-              << n_id;
-          break;
-        default:
-          EXPECT_EQ(Neighbors(s, id, side), s.BottomNeighborFinding(id)) << id;
-          EXPECT_EQ(Neighbors(s, n_id, side), s.BottomNeighborFinding(n_id))
-              << n_id;
-          break;
-      }
-    }
+    CheckNeighbors(s);
   }
 }

--- a/test/stitch.cpp
+++ b/test/stitch.cpp
@@ -273,32 +273,50 @@ void CheckNeighbors(const Stitch& s) {
   }
 }
 
-TEST(Stitch, VerticalSplit1) {
+TEST(Stitch, VerticalSplitMerge1) {
   Example example = Example::Example1();
   auto& s = example.stitch;
   // collect id of existing tiles
   std::vector<Id> ids;
   for (size_t i = 0; i < s.tiles_.size(); i++)
     if (s.tiles_[i].has_value()) ids.push_back(i);
-  // test
+  // test split
+  std::vector<Id> nids;
   for (auto id : ids) {
-    auto n_id = s.VerticalSplit(id, s.Ref(id).coord.x + s.Ref(id).size.x / 2);
-    EXPECT_NE(n_id, id) << "should return id of new tile";
+    auto nid = s.VerticalSplit(id, s.Ref(id).coord.x + s.Ref(id).size.x / 2);
+    EXPECT_NE(nid, id) << "should return id of new tile";
+    CheckNeighbors(s);
+    nids.push_back(nid);
+  }
+  // test merge
+  for (size_t i = 0; i < ids.size(); i++) {
+    Id id = ids[i], nid = nids[i];
+    auto mrg = s.VerticalMerge(id, nid);
+    EXPECT_EQ(id, mrg);
     CheckNeighbors(s);
   }
 }
 
-TEST(Stitch, HorizontalSplit1) {
+TEST(Stitch, HorizontalSplitMerge1) {
   Example example = Example::Example1();
   auto& s = example.stitch;
   // collect id of existing tiles
   std::vector<Id> ids;
   for (size_t i = 0; i < s.tiles_.size(); i++)
     if (s.tiles_[i].has_value()) ids.push_back(i);
-  // test
+  // test split
+  std::vector<Id> nids;
   for (auto id : ids) {
-    auto n_id = s.HorizontalSplit(id, s.Ref(id).coord.y + s.Ref(id).size.y / 2);
-    EXPECT_NE(n_id, id) << "should return id of new tile";
+    auto nid = s.HorizontalSplit(id, s.Ref(id).coord.y + s.Ref(id).size.y / 2);
+    EXPECT_NE(nid, id) << "should return id of new tile";
+    CheckNeighbors(s);
+    nids.push_back(nid);
+  }
+  // test merge
+  for (size_t i = 0; i < ids.size(); i++) {
+    Id id = ids[i], nid = nids[i];
+    auto mrg = s.HorizontalMerge(id, nid);
+    EXPECT_EQ(id, mrg);
     CheckNeighbors(s);
   }
 }

--- a/test/stitch.cpp
+++ b/test/stitch.cpp
@@ -273,6 +273,45 @@ TEST(Stitch, VerticalSplit1) {
   // test
   for (auto id : ids) {
     auto n_id = s.VerticalSplit(id, s.Ref(id).coord.x + s.Ref(id).size.x / 2);
+    EXPECT_NE(n_id, id) << "should return id of new tile";
+    for (auto side : {RIGHT, LEFT, TOP, BOTTOM}) {
+      switch (side) {
+        case RIGHT:
+          EXPECT_EQ(Neighbors(s, id, side), s.RightNeighborFinding(id)) << id;
+          EXPECT_EQ(Neighbors(s, n_id, side), s.RightNeighborFinding(n_id))
+              << n_id;
+          break;
+        case LEFT:
+          EXPECT_EQ(Neighbors(s, id, side), s.LeftNeighborFinding(id)) << id;
+          EXPECT_EQ(Neighbors(s, n_id, side), s.LeftNeighborFinding(n_id))
+              << n_id;
+          break;
+        case TOP:
+          EXPECT_EQ(Neighbors(s, id, side), s.TopNeighborFinding(id)) << id;
+          EXPECT_EQ(Neighbors(s, n_id, side), s.TopNeighborFinding(n_id))
+              << n_id;
+          break;
+        default:
+          EXPECT_EQ(Neighbors(s, id, side), s.BottomNeighborFinding(id)) << id;
+          EXPECT_EQ(Neighbors(s, n_id, side), s.BottomNeighborFinding(n_id))
+              << n_id;
+          break;
+      }
+    }
+  }
+}
+
+TEST(Stitch, HorizontalSplit1) {
+  Example example = Example::Example1();
+  auto& s = example.stitch;
+  // collect id of existing tiles
+  std::vector<Id> ids;
+  for (size_t i = 0; i < s.tiles_.size(); i++)
+    if (s.tiles_[i].has_value()) ids.push_back(i);
+  // test
+  for (auto id : ids) {
+    auto n_id = s.HorizontalSplit(id, s.Ref(id).coord.y + s.Ref(id).size.y / 2);
+    EXPECT_NE(n_id, id) << "should return id of new tile";
     for (auto side : {RIGHT, LEFT, TOP, BOTTOM}) {
       switch (side) {
         case RIGHT:


### PR DESCRIPTION
Split & merge tiles are essential components for tile creation & deletion. #3 

This PR implement `VerticalSplit`, `VerticalMerge`, `HorizontalSplit`, `HorizontalMerge` for splitting and merging tiles.
Test for above are automated: split each tile then merge each split tile pair.