### PR TITLE
Tile delete

### DIFF
--- a/src/stitch.cpp
+++ b/src/stitch.cpp
@@ -274,8 +274,10 @@ std::optional<Tile> Stitch::Delete(Id dead) {
   }
   // merge space tiles if possible
   for (auto d : merge_dead) {
-    HorizontalMerge(d, Ref(d).rt);
-    HorizontalMerge(Ref(d).bl, d);
+    if (Exist(d)) {
+      HorizontalMerge(d, Ref(d).rt);
+      HorizontalMerge(Ref(d).lb, d);
+    }
   }
   return std::optional<Tile>{ret};
 }

--- a/src/stitch.cpp
+++ b/src/stitch.cpp
@@ -1,5 +1,6 @@
 #include "stitch.hpp"
 
+#include <algorithm>
 #include <cassert>
 #include <iostream>
 
@@ -192,6 +193,91 @@ Id Stitch::Insert(Tile tile) {
   HorizontalMerge(Ref(right).lb, right);
   Ref(last_id).is_space = false;
   return last_id;
+}
+
+std::optional<Tile> Stitch::Delete(Id dead) {
+  if (!Exist(dead) || Ref(dead).is_space) return std::nullopt;
+  auto ret = Ref(dead);
+  // change the type of the dead tile to space.
+  Ref(dead).is_space = true;
+  auto top = Ref(dead).UpperRightCorner().y;
+  auto bottom = Ref(dead).LowerLeftCorner().y;
+  // collect all right & left neighbors
+  auto right_neighbors = RightNeighborFinding(dead);
+  auto left_neighbors = LeftNeighborFinding(dead);
+  // split & merge right neighbors
+  auto cut = top;
+  std::vector<Id> split_dead;  // from top to bottom
+  for (auto r : right_neighbors) {
+    if (top < Ref(r).UpperLeftCorner().y && Ref(r).is_space) {
+      // space neighbor containing top of dead tile should be split
+      // this should only happens when visiting the first neighbor
+      HorizontalSplit(r, cut);
+    }
+    cut = Ref(r).LowerLeftCorner().y;  // move down cut edge
+    if (cut > bottom) {                // dead tile need to be cut
+      auto dead_upper = HorizontalSplit(dead, cut);
+      VerticalMerge(dead_upper, r);  // solid r must filed
+      split_dead.push_back(dead_upper);
+    } else if (cut < bottom) {                 // neighbor need to be cut
+      auto r_upper = HorizontalSplit(r, cut);  // solid r must filed
+      VerticalMerge(dead, r_upper);            // solid r must filed
+      split_dead.push_back(dead);
+    } else {                   // no need to cut
+      VerticalMerge(dead, r);  // solid r must filed
+      split_dead.push_back(dead);
+    }
+  }
+  // split & merge left neighbors
+  std::vector<Id> merge_dead;
+  for (auto l = left_neighbors.front();
+       Exist(l) && Ref(l).IsLeftNeighborTo(ret) && split_dead.size();) {
+    if (Ref(l).is_space) {
+      auto l_rt = Ref(l).rt;
+      auto d = split_dead.back();
+      split_dead.pop_back();
+      if (Ref(l).LowerRightCorner().y > Ref(d).LowerLeftCorner().y) {
+        // cut the lower part of d which does not touch l
+        // this should only happens when visiting the first neighbor
+        auto d_upper = HorizontalSplit(d, Ref(l).LowerRightCorner().y);
+        merge_dead.push_back(d);  // d_lower
+        d = d_upper;
+      }
+      if (Ref(l).UpperRightCorner().y > Ref(d).UpperLeftCorner().y) {
+        // cut the lower part of l which touches d, merge
+        auto l_upper = HorizontalSplit(l, Ref(d).UpperLeftCorner().y);
+        VerticalMerge(l, d);
+        merge_dead.push_back(l);  // l_lower & d
+        l = l_upper;
+      } else if (Ref(l).UpperRightCorner().y < Ref(d).UpperLeftCorner().y) {
+        // cut the lower part of d which touches l, merge
+        auto d_upper = HorizontalSplit(d, Ref(l).UpperRightCorner().y);
+        split_dead.push_back(d_upper);  // handle in next iter
+        VerticalMerge(l, d);
+        merge_dead.push_back(l);  // l & d_lower
+        l = l_rt;
+      } else {  // l & d have same vertical span, merge
+        VerticalMerge(l, d);
+        merge_dead.push_back(l);
+        l = l_rt;
+      }
+    } else {
+      // no need to split d if l is solid
+      while (split_dead.size() &&
+             (Ref(l).UpperRightCorner().y >=
+              Ref(split_dead.back()).UpperLeftCorner().y)) {
+        merge_dead.push_back(split_dead.back());
+        split_dead.pop_back();
+      }
+      l = Ref(l).rt;
+    }
+  }
+  // merge space tiles if possible
+  for (auto d : merge_dead) {
+    HorizontalMerge(d, Ref(d).rt);
+    HorizontalMerge(Ref(d).bl, d);
+  }
+  return std::optional<Tile>{ret};
 }
 
 Id Stitch::LastInserted() const {

--- a/src/stitch.hpp
+++ b/src/stitch.hpp
@@ -35,9 +35,10 @@ class Stitch {
   // enumerate all tiles in the given area,
   // each tile is visited after all its upper & left tiles are visited
   std::vector<Id> AreaEnum(const Tile& area, Id start = kNullId) const;
-
+  // return the pointer of the inserted tile if success, else return `kNullId`
   Id Insert(Tile tile);
-  int Delete(Id id);
+  // return the deleted tile if success, else return `std::nullopt`
+  std::optional<Tile> Delete(Id id);
 
 #ifdef GTEST
  public:

--- a/test/test_stitch.cpp
+++ b/test/test_stitch.cpp
@@ -179,7 +179,6 @@ Stitch TestStitch::TestVerticalSplitMerge() const {
   // split
   std::vector<Id> nids;
   for (auto id : ids) {
-    std::cout << "vertical split: " << id << std::endl;
     size_t size = ns.NumTiles();
     const auto& t = ns.Ref(id);
     auto nid = ns.VerticalSplit(id, t.coord.x + t.size.x / 2);
@@ -194,7 +193,6 @@ Stitch TestStitch::TestVerticalSplitMerge() const {
   for (size_t i = 0; i < ids.size(); i++) {
     size_t size = ns.NumTiles();
     Id id = ids[i], nid = nids[i];
-    std::cout << "vertical merge: " << id << " " << nid << std::endl;
     auto mrg = ns.VerticalMerge(id, nid);
     EXPECT_EQ(id, mrg);
     EXPECT_EQ(size, ns.NumTiles() + 1);
@@ -288,5 +286,6 @@ Stitch TestStitch::TestDelete() const {
     CheckTiles(ns);
     CheckStrip(ns);
   }
+  EXPECT_EQ(0, ns.NumTiles());
   return ns;
 }

--- a/test/test_stitch.cpp
+++ b/test/test_stitch.cpp
@@ -89,6 +89,16 @@ void TestStitch::CheckStrip(const Stitch& s) const {
       if (s.Exist(tl.tr)) {
         EXPECT_FALSE(s.Ref(tl.tr).is_space) << id;
       }
+      if (s.Exist(tl.lb) && s.Ref(tl.lb).is_space) {
+        EXPECT_FALSE(s.Ref(tl.lb).coord.x == tl.coord.x &&
+                     s.Ref(tl.lb).size.x == tl.size.x)
+            << id;
+      }
+      if (s.Exist(tl.rt) && s.Ref(tl.rt).is_space) {
+        EXPECT_FALSE(s.Ref(tl.rt).coord.x == tl.coord.x &&
+                     s.Ref(tl.rt).size.x == tl.size.x)
+            << id;
+      }
     }
   }
 }
@@ -275,17 +285,17 @@ Stitch TestStitch::TestInsert(
 Stitch TestStitch::TestDelete() const {
   auto ns = s;
   for (auto id : Tiles(ns)) {
-    auto t = ns.At(id).value();
-    auto opt = ns.Delete(id);
-    if (ns.Ref(id).is_space) {
-      EXPECT_EQ(std::nullopt, opt);
+    auto t = ns.At(id);
+    if (s.Ref(id).is_space) {  // check in the original stitch
+      EXPECT_EQ(std::nullopt, ns.Delete(id)) << id;
     } else {
-      EXPECT_EQ(t, opt.value());
+      EXPECT_EQ(t, ns.Delete(id)) << id;
     }
     CheckNeighbors(ns);
     CheckTiles(ns);
     CheckStrip(ns);
   }
-  EXPECT_EQ(0, ns.NumTiles());
+  EXPECT_EQ(1, ns.NumTiles());
+  for (auto id : Tiles(ns)) EXPECT_TRUE(ns.Ref(id).is_space);
   return ns;
 }

--- a/test/test_stitch.cpp
+++ b/test/test_stitch.cpp
@@ -4,27 +4,28 @@ TestStitch::TestStitch(Stitch&& s,
                        std::array<NeighborGolden, LAST>&& neighbor_golden)
     : s(s), neighbor_golden(neighbor_golden) {
   // check auto generated Neighbors
-  for (auto id : Tiles())
+  for (auto id : Tiles(s))
     for (int side = 0; side < LAST; side++)
-      EXPECT_EQ(neighbor_golden[side][id], Neighbors(id, (Side)side));
-  CheckNeighbors();
-  CheckTiles();
-  CheckStrip();
+      EXPECT_EQ(neighbor_golden[side][id], Neighbors(s, id, (Side)side));
+  CheckNeighbors(s);
+  CheckTiles(s);
+  CheckStrip(s);
 }
 
-std::vector<Id> TestStitch::Tiles() const {
+std::vector<Id> TestStitch::Tiles(const Stitch& stitch) const {
   std::vector<Id> ids;
-  for (size_t i = 0; i < s.tiles_.size(); i++)
-    if (s.Exist(i)) ids.push_back(i);
+  for (size_t i = 0; i < stitch.tiles_.size(); i++)
+    if (stitch.Exist(i)) ids.push_back(i);
   return ids;
 }
 
-std::vector<Id> TestStitch::GoldenNeighbors(Id t, Side side) const {
+std::vector<Id> TestStitch::GoldenNeighbors(const Stitch& s, Id t,
+                                            Side side) const {
   EXPECT_NE(LAST, side) << "Invalid side\n";
   if (!s.Exist(t)) return {};
   // collect neighbors linearly
   std::vector<Id> neighbors;
-  for (auto id : Tiles()) {
+  for (auto id : Tiles(s)) {
     bool is_neighbor = side == RIGHT  ? s.Ref(id).IsRightNeighborTo(s.Ref(t))
                        : side == LEFT ? s.Ref(id).IsLeftNeighborTo(s.Ref(t))
                        : side == TOP  ? s.Ref(id).IsTopNeighborTo(s.Ref(t))
@@ -42,7 +43,7 @@ std::vector<Id> TestStitch::GoldenNeighbors(Id t, Side side) const {
   return neighbors;
 }
 
-std::vector<Id> TestStitch::Neighbors(Id id, Side side) const {
+std::vector<Id> TestStitch::Neighbors(const Stitch& s, Id id, Side side) const {
   EXPECT_NE(LAST, side) << "Invalid side\n";
   return side == RIGHT  ? s.RightNeighborFinding(id)
          : side == LEFT ? s.LeftNeighborFinding(id)
@@ -50,26 +51,26 @@ std::vector<Id> TestStitch::Neighbors(Id id, Side side) const {
                         : s.BottomNeighborFinding(id);
 }
 
-void TestStitch::CheckNeighbors() const {
-  for (auto id : Tiles()) {
+void TestStitch::CheckNeighbors(const Stitch& s) const {
+  for (auto id : Tiles(s)) {
     const auto& t = s.Ref(id);
-    auto rights = GoldenNeighbors(id, RIGHT);
+    auto rights = GoldenNeighbors(s, id, RIGHT);
     EXPECT_EQ(rights, s.RightNeighborFinding(id)) << id;
     EXPECT_EQ(rights.size() ? rights.front() : kNullId, t.tr);
-    auto lefts = GoldenNeighbors(id, LEFT);
+    auto lefts = GoldenNeighbors(s, id, LEFT);
     EXPECT_EQ(lefts, s.LeftNeighborFinding(id)) << id;
     EXPECT_EQ(lefts.size() ? lefts.front() : kNullId, t.bl);
-    auto tops = GoldenNeighbors(id, TOP);
+    auto tops = GoldenNeighbors(s, id, TOP);
     EXPECT_EQ(tops, s.TopNeighborFinding(id)) << id;
     EXPECT_EQ(tops.size() ? tops.front() : kNullId, t.rt);
-    auto bottoms = GoldenNeighbors(id, BOTTOM);
+    auto bottoms = GoldenNeighbors(s, id, BOTTOM);
     EXPECT_EQ(bottoms, s.BottomNeighborFinding(id)) << id;
     EXPECT_EQ(bottoms.size() ? bottoms.front() : kNullId, t.lb);
   }
 }
 
-void TestStitch::CheckTiles() const {
-  std::vector<Id> ids = Tiles();
+void TestStitch::CheckTiles(const Stitch& s) const {
+  std::vector<Id> ids = Tiles(s);
   Len area = 0;
   for (auto x : ids) {
     area += s.Ref(x).size.x * s.Ref(x).size.y;
@@ -78,8 +79,8 @@ void TestStitch::CheckTiles() const {
   EXPECT_FLOAT_EQ(s.size_.x * s.size_.y, area);
 }
 
-void TestStitch::CheckStrip() const {
-  for (auto id : Tiles()) {
+void TestStitch::CheckStrip(const Stitch& s) const {
+  for (auto id : Tiles(s)) {
     const auto& tl = s.Ref(id);
     if (tl.is_space) {
       if (s.Exist(tl.bl)) {
@@ -104,7 +105,7 @@ void TestStitch::TestPointFinding() const {
   for (auto it = starts.begin() + 1; it != starts.end(); it++)
     EXPECT_NE(kNullId, *it);
   // for each starting tile, test each tile's all corners
-  auto ids = Tiles();
+  auto ids = Tiles(s);
   for (auto start : starts) {
     for (auto id : ids) {
       const auto& t = s.tiles_[id].value();
@@ -135,14 +136,15 @@ void TestStitch::TestPointFinding() const {
 }
 
 void TestStitch::TestNeighborFinding() const {
-  for (auto id : Tiles())
+  for (auto id : Tiles(s))
     for (int side = 0; side != LAST; side++)
-      EXPECT_EQ(GoldenNeighbors(id, (Side)side), Neighbors(id, (Side)side));
+      EXPECT_EQ(GoldenNeighbors(s, id, (Side)side),
+                Neighbors(s, id, (Side)side));
 }
 
 void TestStitch::TestAreaSearch() const {
   // AreaSearch self should return self if solid
-  for (auto id : Tiles()) {
+  for (auto id : Tiles(s)) {
     Tile t = s.At(id).value();
     EXPECT_EQ(t.is_space ? kNullId : id, s.AreaSearch(t));
   }
@@ -150,7 +152,8 @@ void TestStitch::TestAreaSearch() const {
 
 void TestStitch::TestAreaEnum() const {
   // AreaEnum self should return {self}
-  for (auto id : Tiles()) EXPECT_EQ(std::vector<Id>{id}, s.AreaEnum(s.Ref(id)));
+  for (auto id : Tiles(s))
+    EXPECT_EQ(std::vector<Id>{id}, s.AreaEnum(s.Ref(id)));
 }
 
 bool StitchEqual(const Stitch& l, const Stitch& r) {
@@ -172,17 +175,18 @@ bool StitchEqual(const Stitch& l, const Stitch& r) {
 
 Stitch TestStitch::TestVerticalSplitMerge() const {
   auto ns = s;
-  auto ids = Tiles();
+  auto ids = Tiles(ns);
   // split
   std::vector<Id> nids;
   for (auto id : ids) {
+    std::cout << "vertical split: " << id << std::endl;
     size_t size = ns.NumTiles();
     const auto& t = ns.Ref(id);
     auto nid = ns.VerticalSplit(id, t.coord.x + t.size.x / 2);
     EXPECT_NE(nid, id) << "should return id of new tile";
     EXPECT_EQ(size + 1, ns.NumTiles());
-    CheckNeighbors();
-    CheckTiles();
+    CheckNeighbors(ns);
+    CheckTiles(ns);
     nids.push_back(nid);
   }
   EXPECT_FALSE(StitchEqual(ns, s));
@@ -190,20 +194,21 @@ Stitch TestStitch::TestVerticalSplitMerge() const {
   for (size_t i = 0; i < ids.size(); i++) {
     size_t size = ns.NumTiles();
     Id id = ids[i], nid = nids[i];
+    std::cout << "vertical merge: " << id << " " << nid << std::endl;
     auto mrg = ns.VerticalMerge(id, nid);
     EXPECT_EQ(id, mrg);
     EXPECT_EQ(size, ns.NumTiles() + 1);
-    CheckNeighbors();
-    CheckTiles();
+    CheckNeighbors(ns);
+    CheckTiles(ns);
   }
-  CheckStrip();
+  CheckStrip(ns);
   EXPECT_TRUE(StitchEqual(ns, s));
   return ns;
 }
 
 Stitch TestStitch::TestHorizontalSplitMerge() const {
   auto ns = s;
-  auto ids = Tiles();
+  auto ids = Tiles(ns);
   // split
   std::vector<Id> nids;
   for (auto id : ids) {
@@ -212,8 +217,8 @@ Stitch TestStitch::TestHorizontalSplitMerge() const {
     auto nid = ns.HorizontalSplit(id, t.coord.y + t.size.y / 2);
     EXPECT_NE(nid, id) << "should return id of new tile";
     EXPECT_EQ(size + 1, ns.NumTiles());
-    CheckNeighbors();
-    CheckTiles();
+    CheckNeighbors(ns);
+    CheckTiles(ns);
     nids.push_back(nid);
   }
   EXPECT_FALSE(StitchEqual(ns, s));
@@ -224,17 +229,17 @@ Stitch TestStitch::TestHorizontalSplitMerge() const {
     auto mrg = ns.HorizontalMerge(id, nid);
     EXPECT_EQ(id, mrg);
     EXPECT_EQ(size, ns.NumTiles() + 1);
-    CheckNeighbors();
-    CheckTiles();
+    CheckNeighbors(ns);
+    CheckTiles(ns);
   }
-  CheckStrip();
+  CheckStrip(ns);
   EXPECT_TRUE(StitchEqual(ns, s));
   return ns;
 }
 
 Stitch TestStitch::TestInsert() const {
   auto ns = s;
-  for (auto id : Tiles()) {
+  for (auto id : Tiles(ns)) {
     size_t size = ns.NumTiles();
     if (ns.Ref(id).is_space) {
       EXPECT_NE(kNullId, ns.Insert(ns.Ref(id))) << id;
@@ -242,9 +247,9 @@ Stitch TestStitch::TestInsert() const {
       EXPECT_EQ(kNullId, ns.Insert(ns.Ref(id))) << id;
     }
     EXPECT_EQ(size, ns.NumTiles());
-    CheckNeighbors();
-    CheckTiles();
-    CheckStrip();
+    CheckNeighbors(ns);
+    CheckTiles(ns);
+    CheckStrip(ns);
     EXPECT_FALSE(StitchEqual(ns, s));
   }
   return ns;
@@ -262,9 +267,26 @@ Stitch TestStitch::TestInsert(
     } else {
       EXPECT_EQ(kNullId, nid) << t;
     }
-    CheckNeighbors();
-    CheckTiles();
-    CheckStrip();
+    CheckNeighbors(ns);
+    CheckTiles(ns);
+    CheckStrip(ns);
+  }
+  return ns;
+}
+
+Stitch TestStitch::TestDelete() const {
+  auto ns = s;
+  for (auto id : Tiles(ns)) {
+    auto t = ns.At(id).value();
+    auto opt = ns.Delete(id);
+    if (ns.Ref(id).is_space) {
+      EXPECT_EQ(std::nullopt, opt);
+    } else {
+      EXPECT_EQ(t, opt.value());
+    }
+    CheckNeighbors(ns);
+    CheckTiles(ns);
+    CheckStrip(ns);
   }
   return ns;
 }

--- a/test/test_stitch.hpp
+++ b/test/test_stitch.hpp
@@ -20,17 +20,17 @@ struct TestStitch {
   TestStitch(Stitch&& s, std::array<NeighborGolden, LAST>&& neighbor_golden);
 
   // get the existing tiles
-  std::vector<Id> Tiles() const;
+  std::vector<Id> Tiles(const Stitch& s) const;
   // get golden `side` neighbors of tile `id` by visiting all tiles
-  std::vector<Id> GoldenNeighbors(Id id, Side side) const;
+  std::vector<Id> GoldenNeighbors(const Stitch& s, Id id, Side side) const;
   // get `side` neighbors of tile `id`
-  std::vector<Id> Neighbors(Id id, Side side) const;
+  std::vector<Id> Neighbors(const Stitch& s, Id id, Side side) const;
   // check neighbors & pointers of all tiles
-  void CheckNeighbors() const;
+  void CheckNeighbors(const Stitch& s) const;
   // check no overlap between tiles & whole plane is covered
-  void CheckTiles() const;
+  void CheckTiles(const Stitch& s) const;
   // check maximum horizontal strip property
-  void CheckStrip() const;
+  void CheckStrip(const Stitch& s) const;
 
   // test on each tile's corners, starting from default & 4 corners of the plane
   void TestPointFinding() const;
@@ -48,4 +48,6 @@ struct TestStitch {
   Stitch TestInsert() const;
   // each case: {insertion is success or not, desired tile}
   Stitch TestInsert(const std::vector<std::tuple<bool, Tile>>& cases) const;
+  // remove each solid tiles
+  Stitch TestDelete() const;
 };

--- a/test/test_stitch.hpp
+++ b/test/test_stitch.hpp
@@ -46,4 +46,6 @@ struct TestStitch {
   Stitch TestHorizontalSplitMerge() const;
   // insert each space tile with its own area
   Stitch TestInsert() const;
+  // each case: {insertion is success or not, desired tile}
+  Stitch TestInsert(const std::vector<std::tuple<bool, Tile>>& cases) const;
 };

--- a/test/test_stitch_1.cpp
+++ b/test/test_stitch_1.cpp
@@ -122,20 +122,10 @@ TEST(HorizontalSplitMerge, Stitch1) {
 TEST(Insert, Stitch1) {
   auto e = Stitch1();
   e.TestInsert();
-  auto& s = e.s;
-  std::vector<std::pair<bool, Tile>> cases = {
+  e.TestInsert({
       {true, {{0, 0}, {1, 24}}},
       {false, {{27, 1}, {2, 4}}},
       {true, {{13, 15}, {6, 7}}},
       {false, {{7, 15}, {6, 6}}},
-  };
-  for (const auto& [success, t] : cases) {
-    if (success) {
-      EXPECT_NE(kNullId, s.Insert(t)) << t;
-    } else {
-      EXPECT_EQ(kNullId, s.Insert(t)) << t;
-    }
-    e.CheckNeighbors();
-    e.CheckStrip();
-  }
+  });
 }

--- a/test/test_stitch_1.cpp
+++ b/test/test_stitch_1.cpp
@@ -129,3 +129,8 @@ TEST(Insert, Stitch1) {
       {false, {{7, 15}, {6, 6}}},
   });
 }
+
+TEST(Delete, Stitch1) {
+  auto e = Stitch1();
+  e.TestDelete();
+}


### PR DESCRIPTION
Implement #21 

Test for `Stitch::Delete` deletes each solid tiles.

`TestStitch::CheckStrip` additionally checks there are no merge-able tiles.

Fix `CheckNeighbors`, `CheckTiles` & `CheckStrip` in `TestStitch`, they did not perform checks on modified `Stitch` previously.